### PR TITLE
Update nock to ^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "Create stub HTTP servers that you can modify on the fly",
   "author": "Tabcorp Digital Team",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TabDigital/real-nock.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TabDigital/real-nock/issues"
+  },
   "main": "src/index.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "http-proxy": "^1.7.3",
-    "nock": "^0.51.0"
+    "nock": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "dependencies": {
     "http-proxy": "^1.7.3",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ var PROXY_COUNT = 0;
 
 module.exports = Stub;
 
+// enable connections to the localhost
+nock.enableNetConnect(new RegExp('localhost|127\\.0\\.0\\.1|::1|0:0:0:0:0:0:0:1'));
+
 function Stub(opts) {
   var self = this;
   var nextSocketId = 0;


### PR DESCRIPTION
Also:
- Enable connections to the localhost resources for the `nock` (disabled by default since `1.0.0`)
- Add repository and bugs sections to the `package.json`
- Fix path to `mocha`: no need to specify full path in `node_modules`
