### PR TITLE
Use the latest nock version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "http-proxy": "^1.7.3",
-    "nock": "^1.1.0"
+    "nock": "^7.4.0"
   },
   "devDependencies": {
     "mocha": "~2.0.1",


### PR DESCRIPTION
Hey, congrats for this repo!
I would like to propose this change on the package.json cause I think it is better (and safe) to use the latest version of nock as dependency, to make use of the latest nock features.
